### PR TITLE
Implement TargetObjectContextProvider

### DIFF
--- a/phirSOFT.ContextProperties/TargetObjectContextProvider.cs
+++ b/phirSOFT.ContextProperties/TargetObjectContextProvider.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace phirSOFT.ContextProperties
+{
+    /// <summary>
+    /// Implements a <see cref="IContextProvider{TProperty,TValue}"/> that redirects the calls to the target object if possible.
+    /// </summary>
+    /// <typeparam name="TProperty">THe type of the property.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    public class TargetObjectContextProvider<TProperty, TValue> : IContextProvider<TProperty, TValue> where TProperty : IContextProperty<TValue>
+    {
+        /// <inheritdoc cref="IContextProvider{TProperty,TValue}.GetValue"/>
+        public TValue GetValue(object targetObject, TProperty targetProperty)
+        {
+            return ((IContextProvider<TProperty, TValue>) targetObject).GetValue(targetObject, targetProperty);
+        }
+
+        /// <inheritdoc cref="IContextProvider{TProperty,TValue}.OverridesValue"/>
+        public bool OverridesValue(object targetObject, TProperty targetProperty)
+        {
+            return targetObject is IContextProvider<TProperty, TValue> provider &&
+                   provider.OverridesValue(targetObject, targetProperty);
+        }
+    }
+}


### PR DESCRIPTION
Provides an IContextProvider\`2 which tries to redirect the calls to the target object. This can be usefull if the underlying object is only known by its interface and its unknown wheter the object does implement the IContextProvicer\`2 interface.